### PR TITLE
Feature/cloudfront function/root handler

### DIFF
--- a/.github/workflows/dev-deployment.yml
+++ b/.github/workflows/dev-deployment.yml
@@ -17,4 +17,4 @@ jobs:
         ref: ${{ github.head_ref }}
     
     - name: Push changes - Init Stage
-      run: git push origin -f dev:stage
+      run: git push origin -f dev:stage 

--- a/docs/cloudformation/geo-ca-stack.yml
+++ b/docs/cloudformation/geo-ca-stack.yml
@@ -279,6 +279,9 @@ Resources:
           LambdaFunctionAssociations:
             - EventType: origin-response
               LambdaFunctionARN: !Ref SecHeadersLambdaEdgeArn
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !GetAtt CloudfrontRootHandler.FunctionMetadata.FunctionARN
         DefaultRootObject: index.html
         HttpVersion: http2
         WebACLId: !Ref WebAclArn
@@ -305,3 +308,40 @@ Resources:
             ErrorCode: 404
             ResponsePagePath: /404.html
             ResponseCode: 404
+
+  CloudfrontRootHandler:
+    Type: AWS::CloudFront::Function
+    Properties: 
+      AutoPublish: true
+      FunctionCode: >
+        function handler(event) {
+          var request = event.request;
+          var uri = request.uri;
+    
+          // Check whether the URI is missing a file name.
+          if (uri.endsWith('/')) {
+              request.uri += 'index.html';
+          }
+          // Check whether the URI is missing a file extension.
+          else if (!uri.includes('.')) {
+              request.uri += '/index.html';
+          }
+    
+          // Redirects requests to the www. url to the non www. url.
+          if (request.headers && request.headers.host && request.headers.host.value.includes('www.')) {
+              var newurl = request.headers.host.value.replace('www.', '')
+              var response = {
+                  statusCode: 301,
+                  statusDescription: 'Moved Permanently',
+                  headers:
+                      { "location": { "value": 'https://' + newurl + request.uri } }
+              }
+              return response;
+          }
+    
+          return request;
+        }
+      FunctionConfig: 
+        Comment: A function run on every request to geo.ca
+        Runtime: cloudfront-js-1.0
+      Name: root-handler


### PR DESCRIPTION
This pull request does two things:

- it adds to the cloudformation the root-handler code that was already in use to redirect certain requests to `/index.html`. This code was currently put in place manually in all environments.
- it adds to the cloudfront function some code to redirect requests to `www.<env>.geo.ca` to `<env>.geo.ca`. This should be better for SEO as it concentrates our traffic to a single host url. 